### PR TITLE
urlencode now handles parse_qs encoding correctly.

### DIFF
--- a/daphne/ws_protocol.py
+++ b/daphne/ws_protocol.py
@@ -33,7 +33,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 clean_headers[name.lower()] = value.encode("latin1")
             # Reconstruct query string
             # TODO: get autobahn to provide it raw
-            query_string = urlencode(request.params).encode("ascii")
+            query_string = urlencode(request.params, doseq=True).encode("ascii")
             # Make sending channel
             self.reply_channel = self.channel_layer.new_channel("!websocket.send.?")
             # Tell main factory about it


### PR DESCRIPTION
The autobahn websocket protocol.py line 2487 uses parse_qs(query) which always returns a list as a return value.
For example:
urllib.parse.parse_qs('room=test') returns {'room': ['test']}. 
In order to parse it correctly later, doseq for urlencode must be set to True.
